### PR TITLE
The writer tests have to run first

### DIFF
--- a/t/testrules.yml
+++ b/t/testrules.yml
@@ -1,0 +1,3 @@
+seq:
+    - seq: t/test01_write.t
+    - par: **


### PR DESCRIPTION
Without this, `HARNESS_OPTIONS=c:j8 cpan ODF::lpOD` often fails as tests don't run or complete in the expected order.

Originally submitted at https://rt.cpan.org/Ticket/Display.html?id=130537